### PR TITLE
Access control changes

### DIFF
--- a/Classes/Converters.swift
+++ b/Classes/Converters.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Provides conversions, when required.
 ///
 /// Meant for internal conversions use only. 
-internal class Convert {
+internal final class Convert {
     
     // MARK:- Number conversion
     

--- a/Classes/DateTimeParsers.swift
+++ b/Classes/DateTimeParsers.swift
@@ -17,7 +17,7 @@ import Foundation
  
  Formerly Named: `ISO8601DateParser` & `CopyrightYearParser`
  */
-class GPXDateParser {
+final class GPXDateParser {
     
     // MARK:- Supporting Variables
     

--- a/Classes/GPXAuthor.swift
+++ b/Classes/GPXAuthor.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Author type, holds information of the creator of the GPX file. A subclass of `GPXPerson`.
-open class GPXAuthor: GPXPerson {
+public final class GPXAuthor: GPXPerson {
     
     /// Default Initializer
     public required init() {

--- a/Classes/GPXBounds.swift
+++ b/Classes/GPXBounds.swift
@@ -12,7 +12,7 @@ import Foundation
  
  This is meant for having two pairs of longitude and latitude, signifying the maximum and minimum, defining the extent / boundaries of a particular element.
  */
-open class GPXBounds: GPXElement, Codable {
+public final class GPXBounds: GPXElement, Codable {
     
     /// Codable Implementation
     private enum CodingKeys: String, CodingKey {

--- a/Classes/GPXCopyright.swift
+++ b/Classes/GPXCopyright.swift
@@ -18,7 +18,7 @@ import Foundation
  - Author / Copyright Holder's name
  
 */
-open class GPXCopyright: GPXElement, Codable {
+public final class GPXCopyright: GPXElement, Codable {
     
     /// Year of the first publication of this copyrighted work.
     ///

--- a/Classes/GPXEmail.swift
+++ b/Classes/GPXEmail.swift
@@ -14,7 +14,7 @@ import Foundation
  
  For example, an email of **"yourname@thisisawebsite.com"**, would have an id of **'yourname'** and a domain of **'thisisawebsite.com'**.
  */
-open class GPXEmail: GPXElement, Codable {
+public final class GPXEmail: GPXElement, Codable {
     
     /// Codable Implementation
     private enum CodingKeys: String, CodingKey {

--- a/Classes/GPXExtensions.swift
+++ b/Classes/GPXExtensions.swift
@@ -14,7 +14,7 @@ import Foundation
  
  This class represents the extended data in a GPX file.
  */
-open class GPXExtensions: GPXElement, Codable {
+public final class GPXExtensions: GPXElement, Codable {
     
     /// Extended children tags
     public var children = [GPXExtensionsElement]()

--- a/Classes/GPXExtensionsElement.swift
+++ b/Classes/GPXExtensionsElement.swift
@@ -45,7 +45,7 @@ open class GPXExtensionsElement: GPXElement, Codable {
     }
     
     /// Default initializer.
-    required init() {
+    required public init() {
         self.name = "Undefined"
     }
     

--- a/Classes/GPXExtensionsElement.swift
+++ b/Classes/GPXExtensionsElement.swift
@@ -12,7 +12,7 @@ import Foundation
 /// This class is a public class as it is representative of all child extension tag types.
 ///
 /// It is also inherits `GPXElement`, and therefore, works like any other 'native' element types.
-public class GPXExtensionsElement: GPXElement, Codable {
+open class GPXExtensionsElement: GPXElement, Codable {
     
     /// Tag name of extension element.
     public var name: String

--- a/Classes/GPXLink.swift
+++ b/Classes/GPXLink.swift
@@ -17,7 +17,7 @@ fileprivate let kCommonWebExtensions: Set = ["htm", "html", "asp", "aspx", "jsp"
     - type of content
     - text of web link (probably a description kind of thing)
  */
-open class GPXLink: GPXElement, Codable {
+public final class GPXLink: GPXElement, Codable {
     
     /// For Codable use
     private enum CodingKeys: String, CodingKey {

--- a/Classes/GPXMetadata.swift
+++ b/Classes/GPXMetadata.swift
@@ -21,7 +21,7 @@ import Foundation
     - Bounds
     - Also supports extensions
  */
-open class GPXMetadata: GPXElement, Codable {
+public final class GPXMetadata: GPXElement, Codable {
     
     /// Name intended for the GPX file.
     public var name: String?

--- a/Classes/GPXParser.swift
+++ b/Classes/GPXParser.swift
@@ -15,7 +15,7 @@ import Foundation
  This parser is already setted up, hence, does not require any handling, and will parse files directly as objects.
  To get the parsed data from a GPX file, simply initialize the parser, and get the `GPXRoot` from `parsedData()`.
  */
-public class GPXParser: NSObject {
+public final class GPXParser: NSObject {
     
     // MARK:- Private Declarations
     

--- a/Classes/GPXPerson.swift
+++ b/Classes/GPXPerson.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A value type that is designated to hold information regarding the person or organisation who has created the GPX file.
-open class GPXPerson: GPXElement, Codable {
+public class GPXPerson: GPXElement, Codable {
     
     /// Name of person who has created the GPX file.
     public var name: String?

--- a/Classes/GPXRawElement.swift
+++ b/Classes/GPXRawElement.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class GPXRawElement {
+final class GPXRawElement {
     /// name tag of element
     var name: String
     

--- a/Classes/GPXRoot.swift
+++ b/Classes/GPXRoot.swift
@@ -12,7 +12,7 @@ import Foundation
  
     `GPXRoot` holds all `metadata`, `waypoints`, `tracks`, `routes` and `extensions` types together before being packaged as a GPX file, or formatted as per GPX schema's requirements.
 */
-open class GPXRoot: GPXElement, Codable {
+public final class GPXRoot: GPXElement, Codable {
     
     /// GPX version that will be generated. Currently, only the latest (version 1.1) is supported.
     public var version: String = "1.1"

--- a/Classes/GPXRoute.swift
+++ b/Classes/GPXRoute.swift
@@ -12,7 +12,7 @@ import Foundation
  
  The route can represent the planned route of a specific trip.
  */
-open class GPXRoute: GPXElement, Codable {
+public final class GPXRoute: GPXElement, Codable {
     
     /// For Codable use
     private enum CodingKeys: String, CodingKey {

--- a/Classes/GPXRoutePoint.swift
+++ b/Classes/GPXRoutePoint.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-open class GPXRoutePoint: GPXWaypoint {
+public final class GPXRoutePoint: GPXWaypoint {
     
     /// Default initializer
     public required init() {

--- a/Classes/GPXTrack.swift
+++ b/Classes/GPXTrack.swift
@@ -14,7 +14,7 @@ import Foundation
  
  Tracks are meant to show the start and finish of a journey, through the track segments that it holds.
  */
-open class GPXTrack: GPXElement, Codable {
+public final class GPXTrack: GPXElement, Codable {
     
     /// for Codable
     private enum CodingKeys: String, CodingKey {
@@ -98,7 +98,7 @@ open class GPXTrack: GPXElement, Codable {
     /// Initialize a new `GPXLink` to the track.
     ///
     /// Method not recommended for use. Please initialize `GPXLink` manually and adding it to the track instead.
-    open func newLink(withHref href: String) -> GPXLink {
+    public func newLink(withHref href: String) -> GPXLink {
         let link = GPXLink(withHref: href)
         return link
     }
@@ -106,26 +106,26 @@ open class GPXTrack: GPXElement, Codable {
     /// Initialize a new `GPXTrackSegement` to the track.
     ///
     /// Method not recommended for use. Please initialize `GPXTrackSegment` manually and adding it to the track instead.
-    open func newTrackSegment() -> GPXTrackSegment {
+    public func newTrackSegment() -> GPXTrackSegment {
         let tracksegment = GPXTrackSegment()
         self.add(trackSegment: tracksegment)
         return tracksegment
     }
     
     /// Adds a single track segment to the track.
-    open func add(trackSegment: GPXTrackSegment?) {
+    public func add(trackSegment: GPXTrackSegment?) {
         if let validTrackSegment = trackSegment {
             tracksegments.append(validTrackSegment)
         }
     }
     
     /// Adds an array of track segments to the track.
-    open func add(trackSegments: [GPXTrackSegment]) {
+    public func add(trackSegments: [GPXTrackSegment]) {
         self.tracksegments.append(contentsOf: trackSegments)
     }
     
     /// Removes a tracksegment from the track.
-    open func remove(trackSegment: GPXTrackSegment) {
+    public func remove(trackSegment: GPXTrackSegment) {
         let contains = tracksegments.contains(trackSegment)
         
         if contains == true {
@@ -136,7 +136,7 @@ open class GPXTrack: GPXElement, Codable {
     }
     
     /// Initializes a new track point in track, then returns the new track point.
-    open func newTrackPointWith(latitude: Double, longitude: Double) -> GPXTrackPoint {
+    public func newTrackPointWith(latitude: Double, longitude: Double) -> GPXTrackPoint {
         var tracksegment: GPXTrackSegment
         
         if let lastTracksegment = tracksegments.last {

--- a/Classes/GPXTrackPoint.swift
+++ b/Classes/GPXTrackPoint.swift
@@ -13,7 +13,7 @@ import Foundation
  A bunch of track points can be used to form a track segement, while track segments form a track.
  (though a single track segment itself is enough to form a track.)
  */
-open class GPXTrackPoint: GPXWaypoint {
+public final class GPXTrackPoint: GPXWaypoint {
     
     /// Default Initializer.
     public required init() {

--- a/Classes/GPXTrackSegment.swift
+++ b/Classes/GPXTrackSegment.swift
@@ -12,7 +12,7 @@ import Foundation
 
  Does not hold additional information by default.
  */
-open class GPXTrackSegment: GPXElement, Codable {
+public final class GPXTrackSegment: GPXElement, Codable {
     
     /// For Codable use
     private enum CodingKeys: String, CodingKey {
@@ -57,7 +57,7 @@ open class GPXTrackSegment: GPXElement, Codable {
     // MARK:- Public Methods
     
     /// Initializes a new trackpoint to segment, and returns the trackpoint.
-    open func newTrackpointWith(latitude: Double, longitude: Double) -> GPXTrackPoint {
+    public func newTrackpointWith(latitude: Double, longitude: Double) -> GPXTrackPoint {
         let trackpoint = GPXTrackPoint(latitude: latitude, longitude: longitude)
         
         self.add(trackpoint: trackpoint)
@@ -66,19 +66,19 @@ open class GPXTrackSegment: GPXElement, Codable {
     }
     
     /// Adds a single track point to this track segment.
-    open func add(trackpoint: GPXTrackPoint?) {
+    public func add(trackpoint: GPXTrackPoint?) {
         if let validPoint = trackpoint {
             trackpoints.append(validPoint)
         }
     }
     
     /// Adds an array of track points to this track segment.
-    open func add(trackpoints: [GPXTrackPoint]) {
+    public func add(trackpoints: [GPXTrackPoint]) {
         self.trackpoints.append(contentsOf: trackpoints)
     }
     
     /// Removes a track point from this track segment.
-    open func remove(trackpoint: GPXTrackPoint) {
+    public func remove(trackpoint: GPXTrackPoint) {
         if let index = trackpoints.firstIndex(of: trackpoint) {
             trackpoints.remove(at: index)
         }

--- a/Classes/GPXWaypoint.swift
+++ b/Classes/GPXWaypoint.swift
@@ -17,7 +17,7 @@ import Foundation
  
  The waypoint should at least contain the attributes of both `latitude` and `longitude` in order to be considered a valid waypoint. Most attributes are optional, and are not required to be implemented.
 */
-open class GPXWaypoint: GPXElement, Codable {
+public class GPXWaypoint: GPXElement, Codable {
     
     // MARK: Codable Implementation
     
@@ -289,7 +289,7 @@ open class GPXWaypoint: GPXElement, Codable {
     ///
     ///   - Warning: Will be deprecated starting version 0.5.0
     @available(*, deprecated, message: "Initialize GPXLink first then, add it to this point type instead.")
-    open func newLink(withHref href: String) -> GPXLink {
+    public func newLink(withHref href: String) -> GPXLink {
         let link = GPXLink(withHref: href)
         self.link = link
         return link


### PR DESCRIPTION
Some classes are no longer subclass-able. Closes #48 

This is to attempt to reduce dynamic dispatches, and to reduce chance of misuse of schema defined elements. Marginal speed increments can therefore be expected.

Modifications of implementations can still happen by extending the elements.