### PR TITLE
Error Handleability within GPX parsing/creating

### DIFF
--- a/Classes/GPXError.swift
+++ b/Classes/GPXError.swift
@@ -25,11 +25,34 @@ public struct GPXError {
     public enum parser: Error {
         case unsupportedVersion
         case issueAt(line: Int)
+        case issueAt(line: Int, error: Error)
         case fileIsNotGPX
         case fileIsNotXMLBased
         case fileDoesNotConformSchema
         case fileIsEmpty
+        case multipleErrorsOccurred
     }
 }
 
-
+struct coordinatesChecker {
+    static func checkError(latitude: Double, longitude: Double) -> Error? {
+        guard latitude >= -90 && latitude <= 90 else {
+            if latitude <= -90 {
+                return GPXError.coordinates.invalidLatitude(dueTo: .underLimit)
+            }
+            else {
+                return GPXError.coordinates.invalidLatitude(dueTo: .overLimit)
+            }
+        }
+        guard longitude >= -180 && longitude <= 180 else {
+            if longitude <= -180 {
+                return GPXError.coordinates.invalidLongitude(dueTo: .underLimit)
+            }
+            else {
+                return GPXError.coordinates.invalidLongitude(dueTo: .overLimit)
+            }
+        }
+        
+        return nil
+    }
+}

--- a/Classes/GPXError.swift
+++ b/Classes/GPXError.swift
@@ -12,8 +12,13 @@ public struct GPXError {
     
     /// Coordinates related errors
     public enum coordinates: Error {
-        case invalidLatitude
-        case invalidLongitude
+        case invalidLatitude(dueTo: reason)
+        case invalidLongitude(dueTo: reason)
+        
+        public enum reason {
+            case underLimit
+            case overLimit
+        }
     }
     
     /// Parser related errors

--- a/Classes/GPXError.swift
+++ b/Classes/GPXError.swift
@@ -26,7 +26,9 @@ public struct GPXError {
         case unsupportedVersion
         case issueAt(line: Int)
         case fileIsNotGPX
+        case fileIsNotXMLBased
         case fileDoesNotConformSchema
+        case fileIsEmpty
     }
 }
 

--- a/Classes/GPXError.swift
+++ b/Classes/GPXError.swift
@@ -1,0 +1,28 @@
+//
+//  GPXError.swift
+//  Pods
+//
+//  Created by Vincent on 4/9/19.
+//
+
+import Foundation
+
+/// Throwable errors for GPX library
+public struct GPXError {
+    
+    /// Coordinates related errors
+    public enum coordinates: Error {
+        case invalidLatitude
+        case invalidLongitude
+    }
+    
+    /// Parser related errors
+    public enum parser: Error {
+        case unsupportedVersion
+        case issueAt(line: Int)
+        case fileIsNotGPX
+        case fileDoesNotConformSchema
+    }
+}
+
+

--- a/Classes/GPXError.swift
+++ b/Classes/GPXError.swift
@@ -12,29 +12,41 @@ public struct GPXError {
     
     /// Coordinates related errors
     public enum coordinates: Error {
+        /// when lat is outside range (-90˚ to 90˚)
         case invalidLatitude(dueTo: reason)
+        /// when lon is outside range (-180˚ to 180˚)
         case invalidLongitude(dueTo: reason)
         
+        /// reason of why a coordinate error is thrown.
         public enum reason {
+            /// < -90˚ (lat) / < -180˚ (lon)
             case underLimit
+            /// > 90˚ (lat) / > 180˚ (lon)
             case overLimit
         }
     }
     
     /// Parser related errors
     public enum parser: Error {
+        /// Thrown when GPX version is < 1.1
         case unsupportedVersion
+        /// When an issue occurred at line, but without further comment.
         case issueAt(line: Int)
+        /// Thrown when issue occurred at line. (Mostly wraps XML parser errors)
         case issueAt(line: Int, error: Error)
+        /// Thrown when file is XML, but not GPX.
         case fileIsNotGPX
+        /// Thrown when file is not XML, let alone GPX.
         case fileIsNotXMLBased
+        /// Thrown when file does not conform schema. (unused)
         case fileDoesNotConformSchema
+        /// Thrown when file is presumed to be empty.
         case fileIsEmpty
+        /// When multiple errors occurred, to give an array of errors.
         case multipleErrorsOccurred(_ errors: [Error])
     }
-}
-
-struct coordinatesChecker {
+    
+    /// Checks if latitude and longitude is valid (within range)
     static func checkError(latitude: Double, longitude: Double) -> Error? {
         guard latitude >= -90 && latitude <= 90 else {
             if latitude <= -90 {

--- a/Classes/GPXError.swift
+++ b/Classes/GPXError.swift
@@ -30,7 +30,7 @@ public struct GPXError {
         case fileIsNotXMLBased
         case fileDoesNotConformSchema
         case fileIsEmpty
-        case multipleErrorsOccurred
+        case multipleErrorsOccurred(_ errors: [Error])
     }
 }
 

--- a/Classes/GPXParser.swift
+++ b/Classes/GPXParser.swift
@@ -270,7 +270,7 @@ extension GPXParser: XMLParserDelegate {
         if elementName == "wpt" || elementName == "trkpt" || elementName == "rtept" {
             guard let lat = Convert.toDouble(from: attributeDict["lat"]) else { errorsOccurred.append(GPXError.parser.issueAt(line: parser.lineNumber)); return }
             guard let lon = Convert.toDouble(from: attributeDict["lon"]) else { errorsOccurred.append(GPXError.parser.issueAt(line: parser.lineNumber)); return }
-            guard let error = coordinatesChecker.checkError(latitude: lat, longitude: lon) else {
+            guard let error = GPXError.checkError(latitude: lat, longitude: lon) else {
                 return }
             errorsOccurred.append(GPXError.parser.issueAt(line: parser.lineNumber, error: error))
             

--- a/Classes/GPXWaypoint.swift
+++ b/Classes/GPXWaypoint.swift
@@ -210,6 +210,16 @@ public class GPXWaypoint: GPXElement, Codable {
         self.longitude = longitude
     }
     
+    convenience init(_ latitude: Double,_ longitude: Double) throws {
+        guard latitude >= -90 && latitude <= 90 else {
+            throw GPXError.coordinates.invalidLatitude
+        }
+        guard longitude >= -180 && longitude <= 180 else {
+            throw GPXError.coordinates.invalidLongitude
+        }
+        self.init(latitude: latitude, longitude: longitude)
+    }
+    
     /// For internal use only
     ///
     /// Initializes a waypoint through a dictionary, with each key being an attribute name.

--- a/Classes/GPXWaypoint.swift
+++ b/Classes/GPXWaypoint.swift
@@ -210,12 +210,22 @@ public class GPXWaypoint: GPXElement, Codable {
         self.longitude = longitude
     }
     
-    convenience init(_ latitude: Double,_ longitude: Double) throws {
+    public convenience init(_ latitude: Double,_ longitude: Double) throws {
         guard latitude >= -90 && latitude <= 90 else {
-            throw GPXError.coordinates.invalidLatitude
+            if latitude <= -90 {
+                throw GPXError.coordinates.invalidLatitude(dueTo: .underLimit)
+            }
+            else {
+                throw GPXError.coordinates.invalidLatitude(dueTo: .overLimit)
+            }
         }
         guard longitude >= -180 && longitude <= 180 else {
-            throw GPXError.coordinates.invalidLongitude
+            if longitude <= -180 {
+                throw GPXError.coordinates.invalidLongitude(dueTo: .underLimit)
+            }
+            else {
+                throw GPXError.coordinates.invalidLongitude(dueTo: .overLimit)
+            }
         }
         self.init(latitude: latitude, longitude: longitude)
     }

--- a/Classes/GPXWaypoint.swift
+++ b/Classes/GPXWaypoint.swift
@@ -210,8 +210,12 @@ public class GPXWaypoint: GPXElement, Codable {
         self.longitude = longitude
     }
     
-    public convenience init(_ latitude: Double,_ longitude: Double) throws {
-        guard let error = coordinatesChecker.checkError(latitude: latitude, longitude: longitude) else {
+    /// Initialize a point type, and verifies that point is within ranges of what latitude and longitude should be.
+    ///
+    /// - SeeAlso:
+    /// init(latitude:longitude:)
+    public convenience init(verifiedLatitude latitude: Double, longitude: Double) throws {
+        guard let error = GPXError.checkError(latitude: latitude, longitude: longitude) else {
             self.init(latitude: latitude, longitude: longitude)
             return }
         

--- a/Classes/GPXWaypoint.swift
+++ b/Classes/GPXWaypoint.swift
@@ -211,23 +211,12 @@ public class GPXWaypoint: GPXElement, Codable {
     }
     
     public convenience init(_ latitude: Double,_ longitude: Double) throws {
-        guard latitude >= -90 && latitude <= 90 else {
-            if latitude <= -90 {
-                throw GPXError.coordinates.invalidLatitude(dueTo: .underLimit)
-            }
-            else {
-                throw GPXError.coordinates.invalidLatitude(dueTo: .overLimit)
-            }
-        }
-        guard longitude >= -180 && longitude <= 180 else {
-            if longitude <= -180 {
-                throw GPXError.coordinates.invalidLongitude(dueTo: .underLimit)
-            }
-            else {
-                throw GPXError.coordinates.invalidLongitude(dueTo: .overLimit)
-            }
-        }
-        self.init(latitude: latitude, longitude: longitude)
+        guard let error = coordinatesChecker.checkError(latitude: latitude, longitude: longitude) else {
+            self.init(latitude: latitude, longitude: longitude)
+            return }
+        
+        throw error
+        
     }
     
     /// For internal use only
@@ -372,5 +361,3 @@ public class GPXWaypoint: GPXElement, Codable {
         }
     }
 }
-
-

--- a/Example/CoreGPX.xcodeproj/project.pbxproj
+++ b/Example/CoreGPX.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
 		8DB72704FC242BCF27592BDE /* Pods_CoreGPX_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7835104F033F117BB9802240 /* Pods_CoreGPX_Tests.framework */; };
+		BF0F3FEF2320C750004E54D3 /* wptError.gpx in Resources */ = {isa = PBXBuildFile; fileRef = BF0F3FED2320C504004E54D3 /* wptError.gpx */; };
 		BF67E92A2217F2EE008B6202 /* GPXTest-TrackPointOnly.gpx in Resources */ = {isa = PBXBuildFile; fileRef = BF67E9292217F2EE008B6202 /* GPXTest-TrackPointOnly.gpx */; };
 		BF7F905D21F7501800359484 /* CreationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7F905C21F7501800359484 /* CreationViewController.swift */; };
 		BFD4523D21E9F17A002ECA3A /* ParseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD4523C21E9F17A002ECA3A /* ParseViewController.swift */; };
@@ -48,6 +49,7 @@
 		7835104F033F117BB9802240 /* Pods_CoreGPX_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CoreGPX_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		820FB2B530C75127A6FBEC73 /* Pods-CoreGPX_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoreGPX_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CoreGPX_Tests/Pods-CoreGPX_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		B1FA67C144CC465C6B228AB8 /* GPXKit.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = GPXKit.podspec; path = ../GPXKit.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		BF0F3FED2320C504004E54D3 /* wptError.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = wptError.gpx; sourceTree = "<group>"; };
 		BF67E9292217F2EE008B6202 /* GPXTest-TrackPointOnly.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "GPXTest-TrackPointOnly.gpx"; sourceTree = "<group>"; };
 		BF693E5022C8A69A00CBCE5A /* CoreGPX.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; fileEncoding = 4; name = CoreGPX.podspec; path = ../CoreGPX.podspec; sourceTree = "<group>"; };
 		BF693E5422C8E71B00CBCE5A /* CoreGPX Playground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "CoreGPX Playground.playground"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -126,6 +128,7 @@
 		607FACE81AFB9204008FA782 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				BF0F3FED2320C504004E54D3 /* wptError.gpx */,
 				BF67E9292217F2EE008B6202 /* GPXTest-TrackPointOnly.gpx */,
 				607FACEB1AFB9204008FA782 /* Tests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
@@ -270,6 +273,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF0F3FEF2320C750004E54D3 /* wptError.gpx in Resources */,
 				BF67E92A2217F2EE008B6202 /* GPXTest-TrackPointOnly.gpx in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/GPXKit/CoreGPX Playground.playground/Contents.swift
+++ b/Example/GPXKit/CoreGPX Playground.playground/Contents.swift
@@ -48,3 +48,11 @@ root.extensions = rootExtensions
 
 print("Completed GPXRoot: \(root.gpx())")
 
+let rt: GPXRoot?
+
+do {
+    rt = try GPXParser(withPath: "https://www.apple.com")?.failibleParsedData(forceContinue: false)
+}
+catch {
+    print(error)
+}

--- a/Example/GPXKit/CoreGPX Playground.playground/Contents.swift
+++ b/Example/GPXKit/CoreGPX Playground.playground/Contents.swift
@@ -48,11 +48,3 @@ root.extensions = rootExtensions
 
 print("Completed GPXRoot: \(root.gpx())")
 
-let rt: GPXRoot?
-
-do {
-    rt = try GPXParser(withPath: "https://www.apple.com")?.failibleParsedData(forceContinue: false)
-}
-catch {
-    print(error)
-}

--- a/Example/GPXKit/CoreGPX Playground.playground/timeline.xctimeline
+++ b/Example/GPXKit/CoreGPX Playground.playground/timeline.xctimeline
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+   </TimelineItems>
+</Timeline>

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -39,6 +39,9 @@
 		A747EE957A27BF62DFD53F20F453081E /* GPXPerson.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE08E6C8AFC4C61AB3EFECB99DEA77BD /* GPXPerson.swift */; };
 		AC613BE2782CB345D67CA6161D274529 /* GPXRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FC7E6D90521F471B7DF7C9C7719C19 /* GPXRoot.swift */; };
 		AF08350B73D09B7E2F4601E9C8173977 /* GPXMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42FE81053B5813BD472CFE7B19B3BA5 /* GPXMetadata.swift */; };
+		BF2F5610231FB67200050AE6 /* GPXError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2F560F231FB67200050AE6 /* GPXError.swift */; };
+		BF2F5611231FB67200050AE6 /* GPXError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2F560F231FB67200050AE6 /* GPXError.swift */; };
+		BF2F5612231FB67200050AE6 /* GPXError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2F560F231FB67200050AE6 /* GPXError.swift */; };
 		BF549406231D3E5E009065E5 /* GPXFix.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF549405231D3E5E009065E5 /* GPXFix.swift */; };
 		BF549407231D3E5E009065E5 /* GPXFix.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF549405231D3E5E009065E5 /* GPXFix.swift */; };
 		BF549408231D3E5E009065E5 /* GPXFix.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF549405231D3E5E009065E5 /* GPXFix.swift */; };
@@ -167,6 +170,7 @@
 		B89C566DDFE64E2FEE67AEBFC0F93C24 /* CoreGPX.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CoreGPX.modulemap; sourceTree = "<group>"; };
 		BB29F038FC4078FC2938D16DBC2946F3 /* CoreGPX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreGPX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD9A90D782E3DAE911978D689A4379A0 /* Pods-CoreGPX_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CoreGPX_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		BF2F560F231FB67200050AE6 /* GPXError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GPXError.swift; path = Classes/GPXError.swift; sourceTree = "<group>"; };
 		BF549405231D3E5E009065E5 /* GPXFix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GPXFix.swift; path = Classes/GPXFix.swift; sourceTree = "<group>"; };
 		BF5A9E1322088463003A5379 /* CoreGPX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreGPX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF5A9E1522088463003A5379 /* CoreGPX_macOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreGPX_macOS.h; sourceTree = "<group>"; };
@@ -284,6 +288,7 @@
 				686D19A9107BC3F54687D84FF3325966 /* GPXCopyright.swift */,
 				8DEC0DC9E6862E8F79D8AE36577B4C30 /* GPXElement.swift */,
 				C8226A2AF2988FE6006D11A4DF1D5076 /* GPXEmail.swift */,
+				BF2F560F231FB67200050AE6 /* GPXError.swift */,
 				BF6F12B322DB67D900B6FD37 /* GPXExtensions */,
 				39158661B12C1C5E1CE517EB0F78E27D /* GPXLink.swift */,
 				A42FE81053B5813BD472CFE7B19B3BA5 /* GPXMetadata.swift */,
@@ -693,6 +698,7 @@
 				8BC1E258921ED7FEAB87224B768A4420 /* GPXBounds.swift in Sources */,
 				4732B1A1675B9649AAAACAD20652E8E3 /* GPXCopyright.swift in Sources */,
 				35E4D9DB8D361BD7F90AB8C11A02CDA8 /* GPXElement.swift in Sources */,
+				BF2F5610231FB67200050AE6 /* GPXError.swift in Sources */,
 				882F5B215566AEDB2A2FD702EB7D36B6 /* GPXEmail.swift in Sources */,
 				70C2AD85987CBB4DDD8B5ECDC0CC739C /* GPXExtensions.swift in Sources */,
 				4593377380E79042C9216EFA56EB6577 /* GPXLink.swift in Sources */,
@@ -731,6 +737,7 @@
 				BF5A9E4F220885F7003A5379 /* GPXElement.swift in Sources */,
 				BF5A9E56220885F7003A5379 /* GPXPoint.swift in Sources */,
 				12DE654822D5794C00C4AD47 /* GPXRawElement.swift in Sources */,
+				BF2F5612231FB67200050AE6 /* GPXError.swift in Sources */,
 				BF5A9E55220885F7003A5379 /* GPXPerson.swift in Sources */,
 				BF6BBEF622439E6A007ED5A9 /* Converters.swift in Sources */,
 				BF5A9E50220885F7003A5379 /* GPXEmail.swift in Sources */,
@@ -763,6 +770,7 @@
 				BF5A9E3B220885F7003A5379 /* GPXElement.swift in Sources */,
 				BF5A9E42220885F7003A5379 /* GPXPoint.swift in Sources */,
 				12DE654722D5794C00C4AD47 /* GPXRawElement.swift in Sources */,
+				BF2F5611231FB67200050AE6 /* GPXError.swift in Sources */,
 				BF5A9E41220885F7003A5379 /* GPXPerson.swift in Sources */,
 				BF6BBEF522439E6A007ED5A9 /* Converters.swift in Sources */,
 				BF5A9E3C220885F7003A5379 /* GPXEmail.swift in Sources */,

--- a/Example/Tests/wptError.gpx
+++ b/Example/Tests/wptError.gpx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1" creator="Open GPX Tracker for iOS">
+	<wpt lat="91.38389" lon="103.785436">
+		<time>2019-05-10T08:53:34Z</time>
+		<name>8:53:34 am</name>
+		<desc>10 May 2019 at 8:53:34 am</desc>
+	</wpt>
+	<trk>
+		<trkseg>
+			<trkpt lat="12.430875" lon="180.87702">
+				<ele>27.882911682128906</ele>
+				<time>2019-05-10T08:19:27Z</time>
+			</trkpt>
+			<trkpt lat="12.449862" lon="131.00468">
+				<ele>27.79437255859375</ele>
+				<time>2019-05-10T08:19:33Z</time>
+			</trkpt>
+		</trkseg>
+	</trk>
+</gpx>


### PR DESCRIPTION
Will not replace, current, non error throwing methods or initialisers. 

This is for if the user desires to handle such errors, as it may not be desirable for the parser to fail without notice, etc.
