### PR TITLE
Fix for date creation issue in specific regions

### DIFF
--- a/Classes/Converters.swift
+++ b/Classes/Converters.swift
@@ -52,6 +52,7 @@ internal final class Convert {
         
         // Timezone should be 0 as GPX uses UTC time, not local time.
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         
         // dateTime（YYYY-MM-DDThh:mm:ssZ）
         formatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"


### PR DESCRIPTION
As reported in [merlos/iOS-Open-GPX-Tracker issue #132](https://github.com/merlos/iOS-Open-GPX-Tracker/issues/132), specific regions like Russia, may cause date creation in time attribute to not conform to ISO8601 standards. 

This fixes that.