### PR TITLE
Fix GPXExtensionsElement for 'no parent' malfunction

### DIFF
--- a/Classes/GPXExtensionsElement.swift
+++ b/Classes/GPXExtensionsElement.swift
@@ -57,25 +57,24 @@ open class GPXExtensionsElement: GPXElement, Codable {
     
     override func addOpenTag(toGPX gpx: NSMutableString, indentationLevel: Int) {
         let attribute = NSMutableString()
-        for (key, value) in attributes {
-            attribute.appendFormat(" %@=\"%@\"", key, value)
+        if !attributes.isEmpty {
+            for (key, value) in attributes {
+                attribute.appendFormat(" %@=\"%@\"", key, value)
+            }
+            gpx.appendOpenTag(indentation: indent(forIndentationLevel: indentationLevel), tag: tagName(), attribute: attribute)
         }
-        gpx.appendOpenTag(indentation: indent(forIndentationLevel: indentationLevel), tag: tagName(), attribute: attribute)
+        else if let text = text {
+            self.addProperty(forValue: text, gpx: gpx, tagName: tagName(), indentationLevel: indentationLevel)
+        }
     }
     
     override func addChildTag(toGPX gpx: NSMutableString, indentationLevel: Int) {
         super.addChildTag(toGPX: gpx, indentationLevel: indentationLevel)
-        if let text = text {
-            self.addProperty(forValue: text, gpx: gpx, tagName: tagName(), indentationLevel: indentationLevel)
-        }
+        
         for child in children {
-            if let text = child.text {
-                self.addProperty(forValue: text, gpx: gpx, tagName: child.tagName(), indentationLevel: indentationLevel)
-            }
-            else {
-                child.gpx(gpx, indentationLevel: indentationLevel)
-            }
+            child.gpx(gpx, indentationLevel: indentationLevel)
         }
         
     }
+ 
 }


### PR DESCRIPTION
This will ~fix~ [issue #58 comment](https://github.com/vincentneo/CoreGPX/issues/58#issuecomment-546661398).

To fix: 
```xml
<tag>
   <tag>100</tag>
</tag>
``` 
when its supposed to be:
```xml
<tag>100</tag>
``` 

@edorphy Can you test with #58 file to replicate and see if issue still occurs? 
I won't close that issue as it does not provide the interface for direct Apple Health Export read/write, while this allows a manual read/write regardless of that.