### PR TITLE
Fix invalid src tag when generating wpt, trkpt or rtept.

### DIFF
--- a/Classes/GPXWaypoint.swift
+++ b/Classes/GPXWaypoint.swift
@@ -305,7 +305,7 @@ public class GPXWaypoint: GPXElement, Codable {
         self.addProperty(forValue: name, gpx: gpx, tagName: "name", indentationLevel: indentationLevel)
         self.addProperty(forValue: comment, gpx: gpx, tagName: "cmt", indentationLevel: indentationLevel)
         self.addProperty(forValue: desc, gpx: gpx, tagName: "desc", indentationLevel: indentationLevel)
-        self.addProperty(forValue: source, gpx: gpx, tagName: "source", indentationLevel: indentationLevel)
+        self.addProperty(forValue: source, gpx: gpx, tagName: "src", indentationLevel: indentationLevel)
         
         if self.link != nil {
             self.link?.gpx(gpx, indentationLevel: indentationLevel)


### PR DESCRIPTION
Previous versions will generate source tag for waypoint types as `<source>` instead of `<src>`.

`<src>` is defined in the schema, not `<source>`.