### PR TITLE
Update for Xcode 12 with SPM

### DIFF
--- a/CoreGPX.podspec
+++ b/CoreGPX.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/ivincentneo'
 
   s.swift_versions = ['4.2', '5.0']
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.9'
   s.watchos.deployment_target = '2.0'
 

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "CoreGPX",
     platforms: [
-        .iOS(.v8), .macOS(.v10_10), .watchOS(.v2)
+        .iOS(.v9), .macOS(.v10_10), .watchOS(.v2)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.


### PR DESCRIPTION
Update dependency in Package.swift to iOS 9 to fix Xcode 12 warning.