### PR TITLE
Supports multiple link element parsing and create.

### DIFF
--- a/Classes/GPXLegacy.swift
+++ b/Classes/GPXLegacy.swift
@@ -150,7 +150,7 @@ public final class GPXLegacyRoot: GPXElement, GPXRootElement {
         if url != nil {
             let mLink = GPXLink(withURL: url)
             mLink.text = urlName
-            meta.link = mLink
+            meta.links.append(mLink)
         }
 
         meta.time = time
@@ -304,8 +304,9 @@ public class GPXLegacyWaypoint: GPXElement, GPXWaypointProtocol {
     
     func upgrade() -> GPXWaypoint {
         let upgraded: GPXWaypoint = self.convert()
-        if let url = url, let urlName = urlName {
-            upgraded.link = GPXLink(url: url, name: urlName)
+        if let url = url, let urlName = urlName,
+           let link = GPXLink(url: url, name: urlName) {
+            upgraded.links.append(link)
         }
         return upgraded
     }
@@ -418,7 +419,9 @@ public class GPXLegacyRoute: GPXElement, GPXRouteType {
         rte.comment = comment
         rte.desc = desc
         rte.source = source
-        rte.link = GPXLink(url: url, name: urlName)
+        if let link = GPXLink(url: url, name: urlName) {
+            rte.links.append(link)
+        }
         rte.number = number
         self.points.forEach { point in
             rte.add(routepoint: point.upgrade())
@@ -456,8 +459,9 @@ public final class GPXLegacyRoutePoint: GPXLegacyWaypoint {
     
     override func upgrade() -> GPXRoutePoint {
         let upgraded: GPXRoutePoint = self.convert()
-        if let url = url, let urlName = urlName {
-            upgraded.link = GPXLink(url: url, name: urlName)
+        if let url = url, let urlName = urlName,
+           let link = GPXLink(url: url, name: urlName) {
+            upgraded.links.append(link)
         }
         return upgraded
     }
@@ -477,8 +481,9 @@ public final class GPXLegacyTrackPoint: GPXLegacyWaypoint {
     
     override func upgrade() -> GPXTrackPoint {
         let upgraded: GPXTrackPoint = self.convert()
-        if let url = url, let urlName = urlName {
-            upgraded.link = GPXLink(url: url, name: urlName)
+        if let url = url, let urlName = urlName,
+           let link = GPXLink(url: url, name: urlName) {
+            upgraded.links.append(link)
         }
         upgraded.extensions = GPXExtensions()
         var dict = [String : String]()
@@ -562,7 +567,9 @@ public class GPXLegacyTrack: GPXElement {
         trk.comment = comment
         trk.desc = desc
         trk.source = source
-        trk.link = GPXLink(url: url, name: urlName)
+        if let link = GPXLink(url: url, name: urlName) {
+            trk.links.append(link)
+        }
         trk.number = number
         self.segments.forEach { segment in
             trk.add(trackSegment: segment.upgrade())

--- a/Classes/GPXMetadata.swift
+++ b/Classes/GPXMetadata.swift
@@ -38,7 +38,13 @@ public final class GPXMetadata: GPXElement, Codable {
     public var copyright: GPXCopyright?
     
     /// A web link, usually one with information regarding the GPX file.
-    public var link: GPXLink?
+    @available(*, deprecated, message: "CoreGPX now support multiple links.", renamed: "links.first")
+    public var link: GPXLink? {
+        return links.first
+    }
+    
+    /// Web links, usually containing information regarding the current GPX file which houses this metadata.
+    public var links = [GPXLink]()
     
     /// Date and time of when the GPX file is created.
     public var time: Date?
@@ -75,7 +81,7 @@ public final class GPXMetadata: GPXElement, Codable {
             case "desc":        self.desc = child.text
             case "author":      self.author = GPXAuthor(raw: child)
             case "copyright":   self.copyright = GPXCopyright(raw: child)
-            case "link":        self.link = GPXLink(raw: child)
+            case "link":        self.links.append(GPXLink(raw: child))
             case "time":        self.time = GPXDateParser.parse(date: child.text)
             case "keywords":    self.keywords = child.text
             case "bounds":      self.bounds = GPXBounds(raw: child)
@@ -107,8 +113,8 @@ public final class GPXMetadata: GPXElement, Codable {
             self.copyright?.gpx(gpx, indentationLevel: indentationLevel)
         }
         
-        if link != nil {
-            self.link?.gpx(gpx, indentationLevel: indentationLevel)
+        for link in links {
+            link.gpx(gpx, indentationLevel: indentationLevel)
         }
         
         self.addProperty(forValue: Convert.toString(from: time), gpx: gpx, tagName: "time", indentationLevel: indentationLevel)

--- a/Classes/GPXRoute.swift
+++ b/Classes/GPXRoute.swift
@@ -20,7 +20,7 @@ public final class GPXRoute: GPXElement, Codable, GPXRouteType {
         case comment = "cmt"
         case desc
         case source = "src"
-        case link
+        case links = "link"
         case type
         case extensions
     }
@@ -37,8 +37,18 @@ public final class GPXRoute: GPXElement, Codable, GPXRouteType {
     /// Source of the route.
     public var source: String?
     
-    /// Additional link to an external resource.
-    public var link: GPXLink?
+    /// A value type for link properties (see `GPXLink`)
+    ///
+    /// Intended for additional information about current route through a web link.
+    @available(*, deprecated, message: "CoreGPX now support multiple links.", renamed: "links.first")
+    public var link: GPXLink? {
+        return links.first
+    }
+    
+    /// A value type for link properties (see `GPXLink`)
+    ///
+    /// Intended for additional information about current route through web links.
+    public var links = [GPXLink]()
     
     /// Type of route.
     public var type: String?
@@ -68,7 +78,7 @@ public final class GPXRoute: GPXElement, Codable, GPXRouteType {
     init(raw: GPXRawElement) {
         for child in raw.children {
             switch child.name {
-            case "link":        self.link = GPXLink()
+            case "link":        self.links.append(GPXLink(raw: child))
             case "rtept":       self.routepoints.append(GPXRoutePoint(raw: child))
             case "name":        self.name = child.text
             case "cmt":         self.comment = child.text
@@ -89,7 +99,7 @@ public final class GPXRoute: GPXElement, Codable, GPXRouteType {
     /// Not recommended for use. Init `GPXRoutePoint` manually, then adding it to route, instead.
     func newLink(withHref href: String) -> GPXLink {
         let link: GPXLink = GPXLink(withHref: href)
-        self.link = link
+        self.links.append(link)
         return link
     }
     
@@ -143,7 +153,7 @@ public final class GPXRoute: GPXElement, Codable, GPXRouteType {
         self.addProperty(forValue: desc, gpx: gpx, tagName: "desc", indentationLevel: indentationLevel)
         self.addProperty(forValue: source, gpx: gpx, tagName: "src", indentationLevel: indentationLevel)
         
-        if let link = link {
+        for link in links {
            link.gpx(gpx, indentationLevel: indentationLevel)
         }
         

--- a/Classes/GPXTrack.swift
+++ b/Classes/GPXTrack.swift
@@ -18,7 +18,7 @@ public final class GPXTrack: GPXElement, Codable {
     
     /// for Codable
     private enum CodingKeys: String, CodingKey {
-        case link
+        case links = "link"
         case tracksegments = "trkseg"
         case name
         case comment = "cmt"
@@ -29,8 +29,18 @@ public final class GPXTrack: GPXElement, Codable {
         case extensions
     }
     
-    /// Holds a web link to external resources regarding the current track.
-    public var link: GPXLink?
+    /// A value type for link properties (see `GPXLink`)
+    ///
+    /// Intended for additional information about current route through a web link.
+    @available(*, deprecated, message: "CoreGPX now support multiple links.", renamed: "links.first")
+    public var link: GPXLink? {
+        return links.first
+    }
+    
+    /// A value type for link properties (see `GPXLink`)
+    ///
+    /// Holds web links to external resources regarding the current track.
+    public var links = [GPXLink]()
     
     /// Array of track segements. Must be included in every track.
     public var tracksegments = [GPXTrackSegment]()
@@ -68,7 +78,7 @@ public final class GPXTrack: GPXElement, Codable {
     init(raw: GPXRawElement) {
         for child in raw.children {
             switch child.name {
-            case "link":        self.link = GPXLink(raw: child)
+            case "link":        self.links.append(GPXLink(raw: child))
             case "trkseg":      self.tracksegments.append(GPXTrackSegment(raw: child))
             case "name":        self.name = child.text
             case "cmt":         self.comment = child.text
@@ -152,7 +162,7 @@ public final class GPXTrack: GPXElement, Codable {
         self.addProperty(forValue: desc, gpx: gpx, tagName: "desc", indentationLevel: indentationLevel)
         self.addProperty(forValue: source, gpx: gpx, tagName: "src", indentationLevel: indentationLevel)
         
-        if let link = link {
+        for link in links {
             link.gpx(gpx, indentationLevel: indentationLevel)
         }
         

--- a/Classes/GPXWaypoint.swift
+++ b/Classes/GPXWaypoint.swift
@@ -42,7 +42,7 @@ public class GPXWaypoint: GPXElement, GPXWaypointProtocol, Codable {
         case positionDilution = "pdop"
         case DGPSid = "dgpsid"
         case ageofDGPSData = "ageofdgpsdata"
-        case link
+        case links = "link"
         case extensions
     }
     
@@ -53,7 +53,15 @@ public class GPXWaypoint: GPXElement, GPXWaypointProtocol, Codable {
     /// A value type for link properties (see `GPXLink`)
     ///
     /// Intended for additional information about current point through a web link.
-    public var link: GPXLink?
+    @available(*, deprecated, message: "CoreGPX now support multiple links.", renamed: "links.first")
+    public var link: GPXLink? {
+        return links.first
+    }
+    
+    /// A value type for link properties (see `GPXLink`)
+    ///
+    /// Intended for additional information about current point through web links.
+    public var links = [GPXLink]()
     
     /// Elevation of current point
     ///
@@ -241,7 +249,7 @@ public class GPXWaypoint: GPXElement, GPXWaypointProtocol, Codable {
             case "cmt":         self.comment = child.text
             case "desc":        self.desc = child.text
             case "src":         self.source = child.text
-            case "link":        self.link = GPXLink(raw: child)
+            case "link":        self.links.append(GPXLink(raw: child))
             case "sym":         self.symbol = child.text
             case "type":        self.type = child.text
             case "fix":         self.fix = GPXFix(rawValue: child.text ?? "none")
@@ -269,7 +277,7 @@ public class GPXWaypoint: GPXElement, GPXWaypointProtocol, Codable {
     @available(*, deprecated, message: "Initialize GPXLink first then, add it to this point type instead.")
     public func newLink(withHref href: String) -> GPXLink {
         let link = GPXLink(withHref: href)
-        self.link = link
+        self.links.append(link)
         return link
     }
     
@@ -307,8 +315,8 @@ public class GPXWaypoint: GPXElement, GPXWaypointProtocol, Codable {
         self.addProperty(forValue: desc, gpx: gpx, tagName: "desc", indentationLevel: indentationLevel)
         self.addProperty(forValue: source, gpx: gpx, tagName: "src", indentationLevel: indentationLevel)
         
-        if self.link != nil {
-            self.link?.gpx(gpx, indentationLevel: indentationLevel)
+        for link in links {
+            link.gpx(gpx, indentationLevel: indentationLevel)
         }
  
         self.addProperty(forValue: symbol, gpx: gpx, tagName: "sym", indentationLevel: indentationLevel)

--- a/Example/CoreGPX.xcodeproj/project.pbxproj
+++ b/Example/CoreGPX.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		12A64AED25DFBBD4006A5B01 /* GPXTest-DualLinks.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 12A64AE325DFBAB9006A5B01 /* GPXTest-DualLinks.gpx */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
@@ -34,6 +35,7 @@
 /* Begin PBXFileReference section */
 		075668C73FF16AA0431AF1CD /* Pods-CoreGPX_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoreGPX_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CoreGPX_Tests/Pods-CoreGPX_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		1199081F763AEFCB013E8280 /* Pods_CoreGPX_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CoreGPX_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		12A64AE325DFBAB9006A5B01 /* GPXTest-DualLinks.gpx */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "GPXTest-DualLinks.gpx"; sourceTree = "<group>"; };
 		25FD7EB183A4A9CE3963AB4F /* Pods-CoreGPX_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoreGPX_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-CoreGPX_Example/Pods-CoreGPX_Example.release.xcconfig"; sourceTree = "<group>"; };
 		505B15A1181144CFF96772E1 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* CoreGPX_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CoreGPX_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -130,6 +132,7 @@
 			children = (
 				BF0F3FED2320C504004E54D3 /* wptError.gpx */,
 				BF67E9292217F2EE008B6202 /* GPXTest-TrackPointOnly.gpx */,
+				12A64AE325DFBAB9006A5B01 /* GPXTest-DualLinks.gpx */,
 				607FACEB1AFB9204008FA782 /* Tests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 			);
@@ -273,6 +276,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				12A64AED25DFBBD4006A5B01 /* GPXTest-DualLinks.gpx in Resources */,
 				BF0F3FEF2320C750004E54D3 /* wptError.gpx in Resources */,
 				BF67E92A2217F2EE008B6202 /* GPXTest-TrackPointOnly.gpx in Resources */,
 			);

--- a/Example/Tests/GPXTest-DualLinks.gpx
+++ b/Example/Tests/GPXTest-DualLinks.gpx
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<gpx version="1.1" creator="Xcode">
+    <trk>
+        <trkseg>
+            <trkpt lat="35.675032" lon="139.722148">
+                <ele>31.098352</ele>
+                <time>2018-11-29T01:48:58Z</time>
+                <link href="https://www.vincent-neo.com">
+                    <text>Vincent Site</text>
+                </link>
+                <link href="https://sunlight.vincent-neo.com">
+                    <text>Get Sunlight</text>
+                </link>
+            </trkpt>
+            <trkpt lat="35.675018" lon="139.722148">
+                <ele>30</ele>
+                <time>2018-11-29T01:50:58Z</time>
+            </trkpt>
+        </trkseg>
+    </trk>
+</gpx>


### PR DESCRIPTION
According to #85, with references to the v1.1 GPX schema, link elements in metadata, route, track and waypoint, should be unbounded. 

Prior versions of CoreGPX, all only support 1 link element within the above parent element types. This pull request should fix the incorrect implementation, and be more compliant towards the schema.

closes #85.