### PR TITLE
Change naming style

### DIFF
--- a/Classes/GPXCompression.swift
+++ b/Classes/GPXCompression.swift
@@ -95,8 +95,8 @@ public class GPXCompression {
         
         if types.contains(.trackpoint) {
              for track in gpx.tracks {
-                        for segment in track.tracksegments {
-                            for trkpt in segment.trackpoints {
+                        for segment in track.segments {
+                            for trkpt in segment.points {
                                 if trkpt.compareCoordinates(with: lastTrackpoints.last) {
                                     lastTrackpoints.append(trkpt)
                                     continue
@@ -111,8 +111,8 @@ public class GPXCompression {
                                             lastTrackpoints = [GPXTrackPoint]()
                                             lastTrackpoints.append(trkpt)
                                         }
-                                        else if let i = segment.trackpoints.firstIndex(of: dupTrkpt) {
-                                            segment.trackpoints.remove(at: i)
+                                        else if let i = segment.points.firstIndex(of: dupTrkpt) {
+                                            segment.points.remove(at: i)
                                         }
                                     }
 
@@ -126,7 +126,7 @@ public class GPXCompression {
          
          if types.contains(.routepoint) {
              for route in gpx.routes {
-                for rtept in route.routepoints {
+                for rtept in route.points {
                    if rtept.compareCoordinates(with: lastRoutepoints.last) {
                         lastRoutepoints.append(rtept)
                         continue
@@ -141,8 +141,8 @@ public class GPXCompression {
                                 lastRoutepoints = [GPXRoutePoint]()
                                 lastRoutepoints.append(rtept)
                             }
-                            else if let i = route.routepoints.firstIndex(of: dupRtept) {
-                                route.routepoints.remove(at: i)
+                            else if let i = route.points.firstIndex(of: dupRtept) {
+                                route.points.remove(at: i)
                             }
                         }
 
@@ -184,12 +184,12 @@ public class GPXCompression {
         
         if types.contains(.trackpoint) {
              for track in gpx.tracks {
-                        for segment in track.tracksegments {
-                            for trkpt in segment.trackpoints {
+                        for segment in track.segments {
+                            for trkpt in segment.points {
                                 if let distance = GPXCompressionCalculate.getDistance(from: lastPointCoordinates, and: trkpt) {
                                     if distance < distanceRadius {
-                                        if let i = segment.trackpoints.firstIndex(of: trkpt) {
-                                            segment.trackpoints.remove(at: i)
+                                        if let i = segment.points.firstIndex(of: trkpt) {
+                                            segment.points.remove(at: i)
                                         }
                                         lastPointCoordinates = nil
                                         continue
@@ -205,11 +205,11 @@ public class GPXCompression {
          
          if types.contains(.routepoint) {
              for route in gpx.routes {
-                for rtept in route.routepoints {
+                for rtept in route.points {
                     if let distance = GPXCompressionCalculate.getDistance(from: lastPointCoordinates, and: rtept) {
                         if distance < distanceRadius {
-                            if let i = route.routepoints.firstIndex(of: rtept) {
-                                route.routepoints.remove(at: i)
+                            if let i = route.points.firstIndex(of: rtept) {
+                                route.points.remove(at: i)
                             }
                             lastPointCoordinates = nil
                             continue
@@ -248,13 +248,13 @@ public class GPXCompression {
         
         if types.contains(.trackpoint) {
             for track in gpx.tracks {
-                       for segment in track.tracksegments {
-                           let trkptCount = segment.trackpoints.count
+                       for segment in track.segments {
+                           let trkptCount = segment.points.count
                            if trkptCount != 0 {
                                let removalAmount = Int(percent * Double(trkptCount))
                                for i in 0...removalAmount {
                                    let randomInt = Int.random(in: 0...trkptCount - (i+1))
-                                   segment.trackpoints.remove(at: randomInt)
+                                   segment.points.remove(at: randomInt)
                                }
                            }
                        }
@@ -264,12 +264,12 @@ public class GPXCompression {
         
         if types.contains(.routepoint) {
             for route in gpx.routes {
-                let rteCount = route.routepoints.count
+                let rteCount = route.points.count
                 if rteCount != 0 {
                     let removalAmount = Int(percent * Double(rteCount))
                     for i in 0...removalAmount {
                         let randomInt = Int.random(in: 0...rteCount - (i+1))
-                        route.routepoints.remove(at: randomInt)
+                        route.points.remove(at: randomInt)
                     }
                 }
             }

--- a/Classes/GPXParser.swift
+++ b/Classes/GPXParser.swift
@@ -236,7 +236,7 @@ public final class GPXParser: NSObject {
         return root
     }
     
-    // MARK:- For >= V1.0 Parser
+    // MARK:- For version <= 1.0 Parser
     ///
     /// Starts parsing, returns parsed `GPXRoot` when done.
     ///

--- a/Classes/GPXRoute.swift
+++ b/Classes/GPXRoute.swift
@@ -59,7 +59,15 @@ public final class GPXRoute: GPXElement, Codable, GPXRouteType {
     /// Route points in the route.
     ///
     /// All route points joined represents a route.
-    public var routepoints = [GPXRoutePoint]()
+    @available(*, deprecated, renamed: "points")
+    public var routepoints: [GPXRoutePoint] {
+        return points
+    }
+    
+    /// Route points in the route.
+    ///
+    /// All route points joined represents a route.
+    public var points = [GPXRoutePoint]()
     
     /// Number of route (possibly a tag for the route)
     public var number: Int?
@@ -79,7 +87,7 @@ public final class GPXRoute: GPXElement, Codable, GPXRouteType {
         for child in raw.children {
             switch child.name {
             case "link":        self.links.append(GPXLink(raw: child))
-            case "rtept":       self.routepoints.append(GPXRoutePoint(raw: child))
+            case "rtept":       self.points.append(GPXRoutePoint(raw: child))
             case "name":        self.name = child.text
             case "cmt":         self.comment = child.text
             case "desc":        self.desc = child.text
@@ -117,21 +125,21 @@ public final class GPXRoute: GPXElement, Codable, GPXRouteType {
     /// Adds a singular route point to the route.
     func add(routepoint: GPXRoutePoint?) {
         if let validPoint = routepoint {
-            routepoints.append(validPoint)
+            points.append(validPoint)
         }
     }
     
     /// Adds an array of route points to the route.
     func add(routepoints: [GPXRoutePoint]) {
-        self.routepoints.append(contentsOf: routepoints)
+        self.points.append(contentsOf: routepoints)
     }
     
     /// Removes a route point from the route.
     func remove(routepoint: GPXRoutePoint) {
-        let contains = routepoints.contains(routepoint)
+        let contains = points.contains(routepoint)
         if contains == true {
-            if let index = routepoints.firstIndex(of: routepoint) {
-                routepoints.remove(at: index)
+            if let index = points.firstIndex(of: routepoint) {
+                points.remove(at: index)
             }
         }
         
@@ -164,7 +172,7 @@ public final class GPXRoute: GPXElement, Codable, GPXRouteType {
             self.extensions?.gpx(gpx, indentationLevel: indentationLevel)
         }
         
-        for routepoint in routepoints {
+        for routepoint in points {
             routepoint.gpx(gpx, indentationLevel: indentationLevel)
         }
     }

--- a/Classes/GPXTrack.swift
+++ b/Classes/GPXTrack.swift
@@ -19,7 +19,7 @@ public final class GPXTrack: GPXElement, Codable {
     /// for Codable
     private enum CodingKeys: String, CodingKey {
         case links = "link"
-        case tracksegments = "trkseg"
+        case segments = "trkseg"
         case name
         case comment = "cmt"
         case desc
@@ -42,8 +42,14 @@ public final class GPXTrack: GPXElement, Codable {
     /// Holds web links to external resources regarding the current track.
     public var links = [GPXLink]()
     
-    /// Array of track segements. Must be included in every track.
-    public var tracksegments = [GPXTrackSegment]()
+    /// Array of track segments. Must be included in every track.
+    @available(*, deprecated, renamed: "segments")
+    public var tracksegments: [GPXTrackSegment] {
+        return segments
+    }
+    
+    /// Array of track segments. Must be included in every track.
+    public var segments = [GPXTrackSegment]()
     
     /// Name of track.
     public var name: String?
@@ -79,7 +85,7 @@ public final class GPXTrack: GPXElement, Codable {
         for child in raw.children {
             switch child.name {
             case "link":        self.links.append(GPXLink(raw: child))
-            case "trkseg":      self.tracksegments.append(GPXTrackSegment(raw: child))
+            case "trkseg":      self.segments.append(GPXTrackSegment(raw: child))
             case "name":        self.name = child.text
             case "cmt":         self.comment = child.text
             case "desc":        self.desc = child.text
@@ -113,22 +119,22 @@ public final class GPXTrack: GPXElement, Codable {
     /// Adds a single track segment to the track.
     public func add(trackSegment: GPXTrackSegment?) {
         if let validTrackSegment = trackSegment {
-            tracksegments.append(validTrackSegment)
+            segments.append(validTrackSegment)
         }
     }
     
     /// Adds an array of track segments to the track.
     public func add(trackSegments: [GPXTrackSegment]) {
-        self.tracksegments.append(contentsOf: trackSegments)
+        self.segments.append(contentsOf: trackSegments)
     }
     
     /// Removes a tracksegment from the track.
     public func remove(trackSegment: GPXTrackSegment) {
-        let contains = tracksegments.contains(trackSegment)
+        let contains = segments.contains(trackSegment)
         
         if contains == true {
-            if let index = tracksegments.firstIndex(of: trackSegment) {
-                tracksegments.remove(at: index)
+            if let index = segments.firstIndex(of: trackSegment) {
+                segments.remove(at: index)
             }
         }
     }
@@ -137,7 +143,7 @@ public final class GPXTrack: GPXElement, Codable {
     public func newTrackPointWith(latitude: Double, longitude: Double) -> GPXTrackPoint {
         var tracksegment: GPXTrackSegment
         
-        if let lastTracksegment = tracksegments.last {
+        if let lastTracksegment = segments.last {
             tracksegment = lastTracksegment
         } else {
             tracksegment = self.newTrackSegment()
@@ -173,7 +179,7 @@ public final class GPXTrack: GPXElement, Codable {
             self.extensions?.gpx(gpx, indentationLevel: indentationLevel)
         }
         
-        for tracksegment in tracksegments {
+        for tracksegment in segments {
             tracksegment.gpx(gpx, indentationLevel: indentationLevel)
         }
         

--- a/Classes/GPXTrackSegment.swift
+++ b/Classes/GPXTrackSegment.swift
@@ -16,13 +16,18 @@ public final class GPXTrackSegment: GPXElement, Codable {
     
     /// For Codable use
     private enum CodingKeys: String, CodingKey {
-        case trackpoints = "trkpt"
+        case points = "trkpt"
         case extensions
     }
     
+    /// Track points stored in current segment.
+    @available(*, deprecated, renamed: "points")
+    public var trackpoints: [GPXTrackPoint] {
+        return points
+    }
     
     /// Track points stored in current segment.
-    public var trackpoints = [GPXTrackPoint]()
+    public var points = [GPXTrackPoint]()
     
     /// Custom Extensions, if needed.
     public var extensions: GPXExtensions?
@@ -42,7 +47,7 @@ public final class GPXTrackSegment: GPXElement, Codable {
     init(raw: GPXRawElement) {
         for child in raw.children {
             switch child.name {
-            case "trkpt":       self.trackpoints.append(GPXTrackPoint(raw: child))
+            case "trkpt":       self.points.append(GPXTrackPoint(raw: child))
             case "extensions":  self.extensions = GPXExtensions(raw: child)
             default: continue
             }
@@ -63,19 +68,19 @@ public final class GPXTrackSegment: GPXElement, Codable {
     /// Adds a single track point to this track segment.
     public func add(trackpoint: GPXTrackPoint?) {
         if let validPoint = trackpoint {
-            trackpoints.append(validPoint)
+            points.append(validPoint)
         }
     }
     
     /// Adds an array of track points to this track segment.
     public func add(trackpoints: [GPXTrackPoint]) {
-        self.trackpoints.append(contentsOf: trackpoints)
+        self.points.append(contentsOf: trackpoints)
     }
     
     /// Removes a track point from this track segment.
     public func remove(trackpoint: GPXTrackPoint) {
-        if let index = trackpoints.firstIndex(of: trackpoint) {
-            trackpoints.remove(at: index)
+        if let index = points.firstIndex(of: trackpoint) {
+            points.remove(at: index)
         }
     }
     
@@ -94,7 +99,7 @@ public final class GPXTrackSegment: GPXElement, Codable {
             self.extensions?.gpx(gpx, indentationLevel: indentationLevel)
         }
         
-        for trackpoint in trackpoints {
+        for trackpoint in points {
             trackpoint.gpx(gpx, indentationLevel: indentationLevel)
         }
     }

--- a/Example/GPXKit/ParseViewController.swift
+++ b/Example/GPXKit/ParseViewController.swift
@@ -45,8 +45,8 @@ class ParseViewController: UIViewController, UITableViewDelegate, UITableViewDat
     func trackpointsCount() -> Int {
         var totalCount: Int = 0
         for track in self.tracks {
-            for trackSegment in track.tracksegments {
-                totalCount += trackSegment.trackpoints.count
+            for trackSegment in track.segments {
+                totalCount += trackSegment.points.count
             }
         }
         return totalCount
@@ -103,8 +103,8 @@ class ParseViewController: UIViewController, UITableViewDelegate, UITableViewDat
             var subtitles = [String]()
             
             for track in self.tracks {
-                for tracksegment in track.tracksegments {
-                    for trackpoint in tracksegment.trackpoints {
+                for tracksegment in track.segments {
+                    for trackpoint in tracksegment.points {
                         coordinates.append("Lat=\(trackpoint.latitude!), Lon=\(trackpoint.longitude!)")
                         subtitles.append("Date:\(trackpoint.time ?? Date()), Ele:\(trackpoint.elevation ?? 0), Ext:\(trackpoint.extensions?.get(from: nil) ?? [String:String]())")
                         

--- a/Example/GPXKit/ViewController.swift
+++ b/Example/GPXKit/ViewController.swift
@@ -38,8 +38,8 @@ class ViewController: UIViewController {
         
         // This example prints all the trackpoint's latitude, longitude and date from the GPX file.
         for track in self.tracks {
-            for tracksegment in track.tracksegments {
-                for trackpoint in tracksegment.trackpoints {
+            for tracksegment in track.segments {
+                for trackpoint in tracksegment.points {
                     print("trackpoint-latitude: \(trackpoint.latitude ?? 0)")
                     print("trackpoint-longitude: \(trackpoint.longitude ?? 0)")
                     print("trackpoint-date: \(trackpoint.time ?? Date())")

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -54,10 +54,10 @@ class CoreGPX_Tests: XCTestCase {
         var firstLongitude = Double()
         
         for track in parsedData!.tracks {
-            for tracksegment in track.tracksegments {
-                count += tracksegment.trackpoints.count
-                firstLatitude = (tracksegment.trackpoints.first?.latitude)!
-                firstLongitude = (tracksegment.trackpoints.first?.longitude)!
+            for tracksegment in track.segments {
+                count += tracksegment.points.count
+                firstLatitude = (tracksegment.points.first?.latitude)!
+                firstLongitude = (tracksegment.points.first?.longitude)!
             }
         }
         
@@ -80,10 +80,10 @@ class CoreGPX_Tests: XCTestCase {
         var firstLongitude = Double()
         
         for track in parsedData.tracks {
-            for tracksegment in track.tracksegments {
-                count += tracksegment.trackpoints.count
-                firstLatitude = (tracksegment.trackpoints.first?.latitude)!
-                firstLongitude = (tracksegment.trackpoints.first?.longitude)!
+            for tracksegment in track.segments {
+                count += tracksegment.points.count
+                firstLatitude = (tracksegment.points.first?.latitude)!
+                firstLongitude = (tracksegment.points.first?.longitude)!
             }
         }
         
@@ -108,9 +108,9 @@ class CoreGPX_Tests: XCTestCase {
         var links = [GPXLink]()
         
         for track in parsedData.tracks {
-            for tracksegment in track.tracksegments {
-                count += tracksegment.trackpoints.count
-                if let first = tracksegment.trackpoints.first {
+            for tracksegment in track.segments {
+                count += tracksegment.points.count
+                if let first = tracksegment.points.first {
                     firstLatitude = first.latitude!
                     firstLongitude = first.longitude!
                     links = first.links
@@ -141,10 +141,10 @@ class CoreGPX_Tests: XCTestCase {
         var firstLongitude = Double()
         
         for track in parsedData.tracks {
-            for tracksegment in track.tracksegments {
-                count += tracksegment.trackpoints.count
-                firstLatitude = (tracksegment.trackpoints.first?.latitude)!
-                firstLongitude = (tracksegment.trackpoints.first?.longitude)!
+            for tracksegment in track.segments {
+                count += tracksegment.points.count
+                firstLatitude = (tracksegment.points.first?.latitude)!
+                firstLongitude = (tracksegment.points.first?.longitude)!
             }
         }
         
@@ -165,10 +165,10 @@ class CoreGPX_Tests: XCTestCase {
         var firstLongitude = Double()
         
         for track in parsedData!.tracks {
-            for tracksegment in track.tracksegments {
-                count += tracksegment.trackpoints.count
-                firstLatitude = (tracksegment.trackpoints.first?.latitude)!
-                firstLongitude = (tracksegment.trackpoints.first?.longitude)!
+            for tracksegment in track.segments {
+                count += tracksegment.points.count
+                firstLatitude = (tracksegment.points.first?.latitude)!
+                firstLongitude = (tracksegment.points.first?.longitude)!
             }
         }
         
@@ -189,10 +189,10 @@ class CoreGPX_Tests: XCTestCase {
         var firstLongitude = Double()
         
         for track in parsedData.tracks {
-            for tracksegment in track.tracksegments {
-                count += tracksegment.trackpoints.count
-                firstLatitude = (tracksegment.trackpoints.first?.latitude)!
-                firstLongitude = (tracksegment.trackpoints.first?.longitude)!
+            for tracksegment in track.segments {
+                count += tracksegment.points.count
+                firstLatitude = (tracksegment.points.first?.latitude)!
+                firstLongitude = (tracksegment.points.first?.longitude)!
             }
         }
         
@@ -276,7 +276,7 @@ class CoreGPX_Tests: XCTestCase {
             return
         }
         let parsedData = GPXParser(withData: data).parsedData()
-        let trackpoints = parsedData!.tracks[0].tracksegments[0].trackpoints
+        let trackpoints = parsedData!.tracks[0].segments[0].points
         
         do {
             let data = try JSONEncoder().encode(trackpoints.first)
@@ -302,7 +302,7 @@ class CoreGPX_Tests: XCTestCase {
             return
         }
         let parsedData = GPXParser(withData: data).parsedData()
-        let trackpoints = parsedData!.tracks[0].tracksegments[0].trackpoints
+        let trackpoints = parsedData!.tracks[0].segments[0].points
         
         /// `data` declared above != `serializedData`
         ///


### PR DESCRIPTION
Currently, naming scheme for segments or points for track and route follows a prefix of the parent tag.

This can lead to unnecessarily restating the origin type of the segment/point:

Accessing the first track point of the first track segment of a track currently works like this:
``` Swift
let first = track.tracksegments.first?.trackpoints.first
```

While this pull request will change the above code to:
```Swift
let first = track.segments.first?.points.first
```

This should also be more Swift-like.

Any comments from anyone?