### PR TITLE
Fix build errors on Linux

### DIFF
--- a/Classes/GPXBounds.swift
+++ b/Classes/GPXBounds.swift
@@ -73,7 +73,7 @@ public final class GPXBounds: GPXElement, Codable {
     // MARK:- GPX
     
     override func addOpenTag(toGPX gpx: NSMutableString, indentationLevel: Int) {
-        let attribute = NSMutableString()
+        let attribute = NSMutableString(string: "")
         
         if let minLatitude = minLatitude {
             attribute.append(" minlat=\"\(minLatitude)\"")

--- a/Classes/GPXCopyright.swift
+++ b/Classes/GPXCopyright.swift
@@ -78,10 +78,10 @@ public final class GPXCopyright: GPXElement, Codable {
     // MARK: GPX XML markup
     
     override func addOpenTag(toGPX gpx: NSMutableString, indentationLevel: Int) {
-        let attribute = NSMutableString()
+        let attribute = NSMutableString(string: "")
         
         if let author = author {
-            attribute.appendFormat(" author=\"%@\"", author)
+            attribute.append(" author=\"\(author)\"")
         }
         
         gpx.appendOpenTag(indentation: indent(forIndentationLevel: indentationLevel), tag: tagName(), attribute: attribute)

--- a/Classes/GPXElement.swift
+++ b/Classes/GPXElement.swift
@@ -38,7 +38,7 @@ open class GPXElement: NSObject {
    
     /// for generating newly tracked data straight into a formatted `String` that holds formatted data according to GPX syntax
     open func gpx() -> String {
-        let gpx = NSMutableString()
+        let gpx = NSMutableString(string: "")
         self.gpx(gpx, indentationLevel: 0)
         return gpx as String
     }
@@ -62,7 +62,7 @@ open class GPXElement: NSObject {
     ///         <trk> // an open tag
     ///         <wpt lat=1.0 lon=2.0> // an open tag with extra attributes
     func addOpenTag(toGPX gpx: NSMutableString, indentationLevel: Int) {
-        gpx.append(String(format: "%@<%@>\r\n", indent(forIndentationLevel: indentationLevel), self.tagName()))
+        gpx.append("\(indent(forIndentationLevel: indentationLevel))<\(self.tagName())>\r\n")
     }
     
     /// Implements a child tag after an open tag, before a close tag.
@@ -92,7 +92,7 @@ open class GPXElement: NSObject {
     ///
     ///         </metadata> // a close tag
     func addCloseTag(toGPX gpx: NSMutableString, indentationLevel: Int) {
-        gpx.append(String(format: "%@</%@>\r\n", indent(forIndentationLevel: indentationLevel), self.tagName()))
+        gpx.append("\(indent(forIndentationLevel: indentationLevel))</\(self.tagName())>\r\n")
     }
     
     
@@ -170,10 +170,10 @@ open class GPXElement: NSObject {
         
         // will append as XML CDATA instead.
         if isCDATA {
-            gpx.appendFormat("%@<%@%@><![CDATA[%@]]></%@>\r\n", indent(forIndentationLevel: indentationLevel), tagName, (attribute != nil) ? " ".appending(attribute!): "", value?.replacingOccurrences(of: "]]>", with: "]]&gt;") ?? "", tagName)
+            gpx.append("\(indent(forIndentationLevel: indentationLevel))<\(tagName)\((attribute != nil) ? " ".appending(attribute!): "")><![CDATA[\(value?.replacingOccurrences(of: "]]>", with: "]]&gt;") ?? "")]]></\(tagName)>\r\n")
         }
         else {
-            gpx.appendFormat("%@<%@%@>%@</%@>\r\n", indent(forIndentationLevel: indentationLevel), tagName, (attribute != nil) ? " ".appending(attribute!): "", value ?? "", tagName)
+            gpx.append("\(indent(forIndentationLevel: indentationLevel))<\(tagName)\((attribute != nil) ? " ".appending(attribute!): "")>\(value ?? "")</\(tagName)>\r\n")
         }
     }
     
@@ -191,7 +191,7 @@ open class GPXElement: NSObject {
     ///         This is indented text (indentationLevel == 1)
     ///             This is indented text (indentationLevel == 2)
     func indent(forIndentationLevel indentationLevel: Int) -> NSMutableString {
-        let result = NSMutableString()
+        let result = NSMutableString(string: "")
         
         for _ in 0..<indentationLevel {
             result.append("\t")

--- a/Classes/GPXEmail.swift
+++ b/Classes/GPXEmail.swift
@@ -70,13 +70,13 @@ public final class GPXEmail: GPXElement, Codable {
     
     // MARK:- GPX
     override func addOpenTag(toGPX gpx: NSMutableString, indentationLevel: Int) {
-        let attribute = NSMutableString()
+        let attribute = NSMutableString(string: "")
         
         if let emailID = emailID {
-            attribute.appendFormat(" id=\"%@\"", emailID)
+            attribute.append(" id=\"\(emailID)\"")
         }
         if let domain = domain {
-            attribute.appendFormat(" domain=\"%@\"", domain)
+            attribute.append(" domain=\"\(domain)\"")
         }
         gpx.appendOpenTag(indentation: indent(forIndentationLevel: indentationLevel), tag: tagName(), attribute: attribute)
     }

--- a/Classes/GPXExtensionsElement.swift
+++ b/Classes/GPXExtensionsElement.swift
@@ -70,10 +70,10 @@ open class GPXExtensionsElement: GPXElement, Codable {
     }
     
     override func addOpenTag(toGPX gpx: NSMutableString, indentationLevel: Int) {
-        let attribute = NSMutableString()
+        let attribute = NSMutableString(string: "")
         if !attributes.isEmpty {
             for (key, value) in attributes {
-                attribute.appendFormat(" %@=\"%@\"", key, value)
+                attribute.append(" \(key)=\"\(value)\"")
             }
             gpx.appendOpenTag(indentation: indent(forIndentationLevel: indentationLevel), tag: tagName(), attribute: attribute)
         }

--- a/Classes/GPXLegacy.swift
+++ b/Classes/GPXLegacy.swift
@@ -181,14 +181,14 @@ public final class GPXLegacyRoot: GPXElement, GPXRootElement {
     }
     
     override func addOpenTag(toGPX gpx: NSMutableString, indentationLevel: Int) {
-        let attribute = NSMutableString()
+        let attribute = NSMutableString(string: "")
         
-        attribute.appendFormat(" xmlns:xsi=\"%@\"", self.xsi)
-        attribute.appendFormat(" xmlns=\"%@\"", self.schema)
-        attribute.appendFormat(" xsi:schemaLocation=\"%@\"", self.schemaLocation)
+        attribute.append(" xmlns:xsi=\"\(self.xsi)\"")
+        attribute.append(" xmlns=\"\(self.schema)\"")
+        attribute.append(" xsi:schemaLocation=\"\(self.schemaLocation)\"")
         
-        attribute.appendFormat(" version=\"%@\"", version.rawValue)
-        attribute.appendFormat(" creator=\"%@\"", creator)
+        attribute.append(" version=\"\(version.rawValue)\"")
+        attribute.append(" creator=\"\(creator)\"")
         
         gpx.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n")
         
@@ -312,7 +312,7 @@ public class GPXLegacyWaypoint: GPXElement, GPXWaypointProtocol {
     }
     
     override func addOpenTag(toGPX gpx: NSMutableString, indentationLevel: Int) {
-        let attribute = NSMutableString()
+        let attribute = NSMutableString(string: "")
         
         if let latitude = latitude {
             attribute.append(" lat=\"\(latitude)\"")

--- a/Classes/GPXLink.swift
+++ b/Classes/GPXLink.swift
@@ -101,10 +101,10 @@ public final class GPXLink: GPXElement, Codable {
     // MARK:- GPX
     
     override func addOpenTag(toGPX gpx: NSMutableString, indentationLevel: Int) {
-        let attribute = NSMutableString()
+        let attribute = NSMutableString(string: "")
         
         if let href = href {
-            attribute.appendFormat(" href=\"%@\"", href)
+            attribute.append(" href=\"\(href)\"")
         }
         gpx.appendOpenTag(indentation: indent(forIndentationLevel: indentationLevel), tag: tagName(), attribute: attribute)
     }

--- a/Classes/GPXParser.swift
+++ b/Classes/GPXParser.swift
@@ -8,6 +8,9 @@
 //  XML Parser is referenced from GitHub, yahoojapan/SwiftyXMLParser.
 
 import Foundation
+#if canImport(FoundationXML)
+import FoundationXML
+#endif // canImport(FoundationXML)
 
  /**
  An event-driven parser (SAX parser), currently parses GPX v1.1 files only.

--- a/Classes/GPXPoint.swift
+++ b/Classes/GPXPoint.swift
@@ -61,7 +61,7 @@ open class GPXPoint: GPXElement, Codable {
     // MARK: GPX
     
     override func addOpenTag(toGPX gpx: NSMutableString, indentationLevel: Int) {
-        let attribute = NSMutableString()
+        let attribute = NSMutableString(string: "")
         if let latitude = latitude {
             attribute.append(" lat=\"\(latitude)\"")
         }

--- a/Classes/GPXRoot.swift
+++ b/Classes/GPXRoot.swift
@@ -309,25 +309,25 @@ public final class GPXRoot: GPXElement, Codable {
     
     // MARK:- GPX
     override func addOpenTag(toGPX gpx: NSMutableString, indentationLevel: Int) {
-        let attribute = NSMutableString()
+        let attribute = NSMutableString(string: "")
         
-        attribute.appendFormat(" xmlns:xsi=\"%@\"", self.xsi)
-        attribute.appendFormat(" xmlns=\"%@\"", self.schema)
+        attribute.append(" xmlns:xsi=\"\(self.xsi)\"")
+        attribute.append(" xmlns=\"\(self.schema)\"")
         
         // for extensions attributes to be appended.
         if let extensionAttributes = self.extensionAttributes {
             for attributeKey in extensionAttributes.keys {
-                attribute.appendFormat(" %@=\"%@\"", attributeKey, extensionAttributes[attributeKey] ?? "Data is invalid")
+                attribute.append(" \(attributeKey)=\"\(extensionAttributes[attributeKey] ?? "Data is invalid")\"")
             }
         }
         
-        attribute.appendFormat(" xsi:schemaLocation=\"%@\"", self.schemaLocation)
+        attribute.append(" xsi:schemaLocation=\"\(self.schemaLocation)\"")
         
-        attribute.appendFormat(" version=\"%@\"", version)
+        attribute.append(" version=\"\(version)\"")
         
         
         if let creator = self.creator {
-            attribute.appendFormat(" creator=\"%@\"", creator)
+            attribute.append(" creator=\"\(creator)\"")
         }
         
         gpx.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n")

--- a/Classes/GPXWaypoint.swift
+++ b/Classes/GPXWaypoint.swift
@@ -290,7 +290,7 @@ public class GPXWaypoint: GPXElement, GPXWaypointProtocol, Codable {
     // MARK:- GPX
     
     override func addOpenTag(toGPX gpx: NSMutableString, indentationLevel: Int) {
-        let attribute = NSMutableString()
+        let attribute = NSMutableString(string: "")
         
         if let latitude = latitude {
             attribute.append(" lat=\"\(latitude)\"")

--- a/Classes/NSMutableString+XML.swift
+++ b/Classes/NSMutableString+XML.swift
@@ -23,7 +23,7 @@ extension NSMutableString {
     ///     "%@<%@%@>\r\n"
     ///     //indentations <tagName attributes> \r\n
     func appendOpenTag(indentation: NSMutableString, tag: String, attribute: NSMutableString) {
-        self.appendFormat("%@<%@%@>\r\n", indentation, tag, attribute)
+        self.append("\(indentation)<\(tag)\(attribute)>\r\n")
     }
     
     /// Appends a close tag
@@ -36,11 +36,11 @@ extension NSMutableString {
     ///     "%@</%@>\r\n"
     ///     //indentations </tagName> \r\n
     func appendCloseTag(indentation: NSMutableString, tag: String) {
-        self.appendFormat("%@</%@>\r\n", indentation, tag)
+        self.append("\(indentation)</\(tag)>\r\n")
     }
     
     /// Appends attributes to a tag
     func appendAttributeTag(_ attribution: String, value: CVarArg) {
-        self.appendFormat(" %@=\"%@\"", attribution, value)
+        self.append(" \(attribution)=\"\(value)\"")
     }
 }


### PR DESCRIPTION
The `String(format:_:)` initializer, the `NSMutableString()` initializer, and `NSMutableString`'s `appendFormat(_:)` method are unavailable on Linux, so I replaced them with functionally equivalent alternatives. Additionally, on Linux, the various XML classes in Foundation have been relocated to FoundationXML, so I added a conditional import for it.