### PR TITLE
[ADD] Parameterized initializers

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Classes/GPXPoint.swift
+++ b/Classes/GPXPoint.swift
@@ -36,6 +36,15 @@ open class GPXPoint: GPXElement, Codable {
         self.longitude = longitude
     }
     
+    /// Initialize with elevation, time, latitude,  longitude
+    public init(elevation: Double? = nil, time: Date? = nil, latitude: Double? = nil, longitude: Double? = nil) {
+        super.init()
+        self.elevation = elevation
+        self.time = time
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+    
     /// Inits native element from raw parser value
     ///
     /// - Parameters:

--- a/Classes/GPXPointSegment.swift
+++ b/Classes/GPXPointSegment.swift
@@ -37,6 +37,11 @@ open class GPXPointSegment: GPXElement, Codable {
         }
     }
     
+    /// Initialize with points
+    public init(points: [GPXPoint]) {
+        self.points = points
+    }
+    
     // MARK:- Public Methods
     
     /// Adds a new point to segment, and returns the added point.

--- a/Classes/GPXRoot.swift
+++ b/Classes/GPXRoot.swift
@@ -95,6 +95,21 @@ public final class GPXRoot: GPXElement, Codable {
         self.creator = creator
     }
     
+    /// Initialize with values
+    ///
+    /// - Parameters:
+    ///     - version: GPX version that will be generated
+    ///     - creator: Name of the creator of the GPX content
+    ///     - metadata: Metadata to be included in your GPX content
+    ///     - waypoints:  Array of waypoints
+    ///     - routes: Array of routes
+    ///     - tracks: Array of tracks
+    ///     - extensions: Items for extensions to GPX schema (if any).
+    ///     Leave it as is, if used without modification to GPX schema
+    public init(version: String = "1.1", creator: String? = nil, metadata: GPXMetadata? = nil, waypoints: [GPXWaypoint] = [], routes: [GPXRoute] = [], tracks: [GPXTrack] = [], extensions: GPXExtensions? = nil) {
+        
+    }
+    
     /// Inits native element from raw parser value
     ///
     /// - Parameters:

--- a/Classes/GPXRoute.swift
+++ b/Classes/GPXRoute.swift
@@ -79,6 +79,29 @@ public final class GPXRoute: GPXElement, Codable, GPXRouteType {
         super.init()
     }
     
+    /// Initializer with values for convenience
+    ///
+    /// - Parameters:
+    ///     - name: Name of the route.
+    ///     - comment: Additional comment of the route.
+    ///     - desc: Description of the route.
+    ///     - source:  Source of the route.
+    ///     - links: A value type for link properties (see `GPXLink`)
+    ///     Intended for additional information about current route through web links.
+    ///     - type: Type of route.
+    ///     - extensions: Items for extensions to GPX schema (if any).
+    public init(name: String? = nil, comment: String? = nil, desc: String? = nil, source: String? = nil, links: [GPXLink] = [], type: String? = nil, extensions: GPXExtensions? = nil, points: [GPXRoutePoint] = [], number: Int? = nil) {
+        self.name = name
+        self.comment = comment
+        self.desc = desc
+        self.source = source
+        self.links = links
+        self.type = type
+        self.extensions = extensions
+        self.points = points
+        self.number = number
+    }
+    
     /// Inits native element from raw parser value
     ///
     /// - Parameters:

--- a/Classes/GPXTrack.swift
+++ b/Classes/GPXTrack.swift
@@ -77,6 +77,30 @@ public final class GPXTrack: GPXElement, Codable {
         super.init()
     }
     
+    /// Initialize with values
+    ///
+    /// - Parameters:
+    ///     - links: A value type for link properties (see `GPXLink`)
+    ///      Holds web links to external resources regarding the current track.
+    ///     - segments: Array of track segments. Must be included in every track.
+    ///     - name: Name of track.
+    ///     - comment: Additional comment of track.
+    ///     - desc: A full description of the track. Can be of any length.
+    ///     - source: Source of track.
+    ///     - number: GPS track number.
+    ///     - type: Type of current track.
+    ///     - extensions: Custom Extensions of track, if needed.
+    public init(links: [GPXLink] = [], segments: [GPXTrackSegment] = [], name: String? = nil, comment: String? = nil, desc: String? = nil, source: String? = nil, number: Int? = nil, type: String? = nil, extensions: GPXExtensions? = nil) {
+        self.links = links
+        self.segments = segments
+        self.name = name
+        self.comment = comment
+        self.desc = desc
+        self.source = source
+        self.number = number
+        self.type = type
+        self.extensions = extensions
+    }
     /// Inits native element from raw parser value
     ///
     /// - Parameters:

--- a/Classes/GPXTrackPoint.swift
+++ b/Classes/GPXTrackPoint.swift
@@ -26,6 +26,10 @@ public final class GPXTrackPoint: GPXWaypoint {
         super.init(latitude: latitude, longitude: longitude)
     }
     
+    public override init(links: [GPXLink] = [], elevation: Double? = nil, time: Date? = nil, magneticVariation: Double? = nil, geoidHeight: Double? = nil, source: String? = nil, type: String? = nil, satellites: Int? = nil, horizontalDilution: Double? = nil, verticalDilution: Double? = nil, positionDilution: Double? = nil, extensions: GPXExtensions? = nil, latitude: Double? = nil, longitude: Double? = nil) {
+        super.init(links: links, elevation: elevation, time: time, magneticVariation: magneticVariation, geoidHeight: geoidHeight, source: source, type: type, satellites: satellites, horizontalDilution: horizontalDilution, verticalDilution: verticalDilution, positionDilution: positionDilution, extensions: extensions, latitude: latitude, longitude: longitude)
+    }
+    
     override init(raw: GPXRawElement) {
         super.init(raw: raw)
     }

--- a/Classes/GPXTrackSegment.swift
+++ b/Classes/GPXTrackSegment.swift
@@ -40,6 +40,16 @@ public final class GPXTrackSegment: GPXElement, Codable {
         super.init()
     }
     
+    /// Inits segment from
+    ///
+    /// - Parameters:
+    ///     - points: Track points of the segment.
+    ///     - extensions: Custom Extensions, if needed.
+    public init(points: [GPXTrackPoint] = [], extensions: GPXExtensions? = nil) {
+        self.points = points
+        self.extensions = extensions
+    }
+    
     /// Inits native element from raw parser value
     ///
     /// - Parameters:

--- a/Classes/GPXWaypoint.swift
+++ b/Classes/GPXWaypoint.swift
@@ -218,6 +218,29 @@ public class GPXWaypoint: GPXElement, GPXWaypointProtocol, Codable {
         self.longitude = longitude
     }
     
+    /// Initialize with parameters.
+    ///
+    /// - Parameters:
+    ///     - latitude: latitude value of the waypoint, in `Double` or `CLLocationDegrees`, **WGS 84** datum only. Should be within the ranges of **-90.0 to 90.0**
+    ///     - longitude: longitude value of the waypoint, in `Double` or `CLLocationDegrees`, **WGS 84** datum only. Should be within the ranges of **-180.0 to 180.0**
+    ///
+    public init(links: [GPXLink] = [], elevation: Double? = nil, time: Date? = nil, magneticVariation: Double? = nil, geoidHeight: Double? = nil, source: String? = nil, type: String? = nil, satellites: Int? = nil, horizontalDilution: Double? = nil, verticalDilution: Double? = nil, positionDilution: Double? = nil, extensions: GPXExtensions? = nil, latitude: Double? = nil, longitude: Double? = nil) {
+        self.links = links
+        self.elevation = elevation
+        self.time = time
+        self.magneticVariation = magneticVariation
+        self.geoidHeight = geoidHeight
+        self.source = source
+        self.type = type
+        self.satellites = satellites
+        self.horizontalDilution = horizontalDilution
+        self.verticalDilution = verticalDilution
+        self.positionDilution = positionDilution
+        self.extensions = extensions
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+    
     /// Initialize a point type, and verifies that point is within ranges of what latitude and longitude should be.
     ///
     /// - SeeAlso:


### PR DESCRIPTION
Added initializers with all parameters to enable easier usage with functional programming.

Instead of 

`let root = GPXRoot(creator: "Your app name here!")
root.add(waypoints: arrayOfWaypoints) // adds an array of waypoints

You can now use:

`let root =  GPXRoot(creator: "Your app name here!", waypoints: arrayOfWaypoints)`