### PR TITLE
Add elevation to trackpoint attributes

### DIFF
--- a/Classes/GPXWaypoint.swift
+++ b/Classes/GPXWaypoint.swift
@@ -261,6 +261,7 @@ public class GPXWaypoint: GPXElement, GPXWaypointProtocol, Codable {
     init(raw: GPXRawElement) {
         self.latitude = Convert.toDouble(from: raw.attributes["lat"])
         self.longitude = Convert.toDouble(from: raw.attributes["lon"])
+        self.elevation = Convert.toDouble(from: raw.attributes["ele"])
         
         for child in raw.children {
             switch child.name {


### PR DESCRIPTION
I have a gpx file that contains elevation inside of the track point attributes that does not get parsed.

This is the schema definition:

https://www.topografix.com/GPX/1/1/gpx.xsd

This is the file:

https://www.gaiagps.com/hike/259034/gunung-kinabalu-via-timpohon-summit-trail/

`<trkpt lat="6.028831" lon="116.547172" ele="1878.0"/>`